### PR TITLE
SDK-248 - fix NPE when response is unparsable

### DIFF
--- a/src/main/java/com/solidfire/client/ServiceBase.java
+++ b/src/main/java/com/solidfire/client/ServiceBase.java
@@ -35,6 +35,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.lang.String.format;
+
 import static com.solidfire.client.VersioningUtils.*;
 
 /**
@@ -161,8 +163,11 @@ public class ServiceBase {
 
         try {
             final JsonReader reader = new JsonReader(new StringReader(response));
+
             reader.setLenient(true);
+
             final JsonObject resultObj = gson.fromJson(reader, JsonObject.class);
+
             if (resultObj.has("error")) {
                 throw extractApiError(resultObj.get("error"));
             } else {
@@ -171,13 +176,13 @@ public class ServiceBase {
         } catch (ClassCastException e) {
             final Pattern pattern = Pattern.compile("<p> (.*?)</p>");
             final Matcher matcher = pattern.matcher(response);
-            while (matcher.find()) {
+            if (matcher.find()) {
                 throw new ApiServerException("Not Found", "404", matcher.group(1));
             }
-            throw new ApiException(response, e);
-        } catch (JsonSyntaxException e) {
+            throw new ApiException(format("There was a problem parsing the response from the server. ( response=%s )", response), e);
+        } catch (NullPointerException | JsonParseException e) {
             log.debug(response);
-            throw new ApiException(response, e);
+            throw new ApiException(format("There was a problem parsing the response from the server. ( response=%s )", response));
 
         }
     }

--- a/src/test/scala/com/solidfire/client/ServiceBaseSuite.scala
+++ b/src/test/scala/com/solidfire/client/ServiceBaseSuite.scala
@@ -2,40 +2,59 @@ package com.solidfire.client
 
 import java.io.StringReader
 
-import com.google.gson.{ Gson, JsonObject }
 import com.google.gson.stream.JsonReader
+import com.google.gson.{Gson, JsonObject}
 import com.solidfire.serialization.GsonUtil
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{ Matchers, BeforeAndAfter, WordSpec }
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
 /**
- * Created by Jason Ryan Womack on 9/16/15.
- */
-class ServiceBaseSuite extends WordSpec with BeforeAndAfter with MockitoSugar with Matchers   {
+  * Created by Jason Ryan Womack on 9/16/15.
+  */
+class ServiceBaseSuite extends WordSpec with BeforeAndAfter with MockitoSugar with Matchers {
 
   var serviceBase: ServiceBase = null
 
   before {
-    serviceBase = new ServiceBase(mock[RequestDispatcher]);
+    serviceBase = new ServiceBase( mock[RequestDispatcher] );
+  }
+
+  def convertResponseToJsonObject( response: String ): JsonObject = {
+    val gson: Gson = GsonUtil.getDefaultBuilder.create
+    val reader: JsonReader = new JsonReader( new StringReader( response ) )
+    reader.setLenient( true )
+
+    gson.fromJson( reader, classOf[JsonObject] )
   }
 
   "extractApiError" should {
-    def convertResponseToJsonObject(response: String): JsonObject = {
-      val gson: Gson = GsonUtil.getDefaultBuilder.create
-      val reader: JsonReader = new JsonReader( new StringReader( response ) )
-      reader.setLenient( true )
-
-      gson.fromJson( reader, classOf[JsonObject] )
-    }
     "always return a non null instance" in {
-      serviceBase.extractApiError(convertResponseToJsonObject("{}")) should not be null
+      serviceBase.extractApiError( convertResponseToJsonObject( "{}" ) ) should not be null
     }
     "map fields to exception" in {
-      val error = serviceBase.extractApiError(convertResponseToJsonObject("{\"name\":\"aName\", \"code\":\"aCode\", \"message\":\"aMessage\"}"))
-      error.getName should be ("aName")
-      error.getCode should be ("aCode")
-      error.getMessage should be ("aMessage")
+      val error = serviceBase.extractApiError( convertResponseToJsonObject( "{\"name\":\"aName\", \"code\":\"aCode\", \"message\":\"aMessage\"}" ) )
+      error.getName should be( "aName" )
+      error.getCode should be( "aCode" )
+      error.getMessage should be( "aMessage" )
     }
 
+  }
+
+  "decodeResponseJson" should {
+    "throw apiException when the response is null" in {
+      the[ApiException] thrownBy {
+        serviceBase.decodeResponseJson( null, classOf[Any] )
+      } should have message "There was a problem parsing the response from the server. ( response=null )"
+    }
+    "throw apiException when the response is empty" in {
+      the[ApiException] thrownBy {
+        serviceBase.decodeResponseJson( "", classOf[Any] )
+      } should have message "There was a problem parsing the response from the server. ( response= )"
+    }
+    "throw apiException when the response is not json" in {
+      the[ApiException] thrownBy {
+        serviceBase.decodeResponseJson( "I Cause Errors", classOf[Any] )
+      } should have message "There was a problem parsing the response from the server. ( response=I Cause Errors )"
+    }
   }
 }

--- a/src/test/scala/com/solidfire/serialization/DateTimeAdapterTest.scala
+++ b/src/test/scala/com/solidfire/serialization/DateTimeAdapterTest.scala
@@ -24,17 +24,17 @@ class DateTimeAdapterTest extends WordSpec with Matchers {
     }
     "encode a DateTime to ISO 8601 Zulu time" in {
       val input = new DateTime( 2012, 3, 14, 15, 9, 26, 535, DateTimeZone.UTC )
-      val output = gson.toJsonTree( input, classOf[DateTime] ).getAsJsonPrimitive( ).getAsString( )
+      val output = gson.toJsonTree( input, classOf[DateTime] ).getAsJsonPrimitive.getAsString
       output should be( "2012-03-14T15:09:26.535Z" )
     }
     "encode a non-UTC time into the equivalent UTC" in {
       val input = new DateTime( 2012, 3, 14, 20, 9, 26, 535, DateTimeZone.forOffsetHours( +5 ) )
-      val output = gson.toJsonTree( input, classOf[DateTime] ).getAsJsonPrimitive( ).getAsString( )
+      val output = gson.toJsonTree( input, classOf[DateTime] ).getAsJsonPrimitive.getAsString
       output should be( "2012-03-14T15:09:26.535Z" )
     }
     "encode a null time to `null`" in {
       val output = gson.toJsonTree( null, classOf[DateTime] )
-      output.isJsonNull( ) should be( true )
+      output.isJsonNull should be( true )
     }
   }
 }

--- a/src/test/scala/com/solidfire/serialization/OptionalAdapterTest.scala
+++ b/src/test/scala/com/solidfire/serialization/OptionalAdapterTest.scala
@@ -43,7 +43,7 @@ class OptionalAdapterTest extends WordSpec with Matchers {
     "decode a properly formatted Optional<String> with empty value" in {
       val input = "{\"optional\":\"\"}"
       val output = gson.fromJson( input, classOf[TestString] )
-      output.optional.isPresent( ) should be( false )
+      output.optional.isPresent should be( false )
     }
 
     "decode a properly formatted Optional<int>" in {


### PR DESCRIPTION
Fixes a problem encountered when the service disconnects before a response is completely delivered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-java/9)
<!-- Reviewable:end -->
